### PR TITLE
Contact form: show post-submit confirmation and remove FormSubmit activation note

### DIFF
--- a/src/Components/Form.js
+++ b/src/Components/Form.js
@@ -6,6 +6,12 @@ const Form = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [botField, setBotField] = useState("");
 
+  const isSubmitted = useMemo(() => {
+    if (typeof window === "undefined") return false;
+    const query = new URLSearchParams(window.location.search);
+    return query.get("submitted") === "true";
+  }, []);
+
   const currentUrl = useMemo(() => {
     if (typeof window === "undefined") return "";
     return window.location.href;
@@ -37,7 +43,7 @@ const Form = () => {
           <input type="hidden" name="_subject" value="Portfolio Contact: New Message" />
           <input type="hidden" name="_captcha" value="false" />
           <input type="hidden" name="_template" value="table" />
-          <input type="hidden" name="_next" value={currentUrl} />
+          <input type="hidden" name="_next" value={currentUrl ? `${currentUrl.split("?")[0]}?submitted=true` : ""} />
 
           <label htmlFor="name">Your Name</label>
           <input id="name" name="name" type="text" placeholder="John Doe" required />
@@ -69,9 +75,7 @@ const Form = () => {
             {isSubmitting ? "Sending..." : "Send Message"}
           </button>
 
-          <p className="form-note">
-            On first use, FormSubmit may send an activation email to enable delivery.
-          </p>
+          {isSubmitted && <p className="form-note">Message has been sent. I will contact you soon.</p>}
         </form>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Remove a misleading FormSubmit activation note and provide clear user feedback after a message is sent.
- Ensure the feedback message is shown after the external form redirect by encoding the submission state in the URL.

### Description
- Removed the static paragraph that warned about FormSubmit activation emails from the contact form UI.
- Added an `isSubmitted` memo that reads `?submitted=true` from the URL to determine post-submit state.
- Updated the hidden `_next` input to redirect back to the same page with `?submitted=true` so the confirmation can be displayed after redirect.
- When `isSubmitted` is true, display the message: "Message has been sent. I will contact you soon." in the form note area.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b9f7eaac832aaabf1d0e7f7a75d8)