### PR TITLE
Add AJAX form submission with success/error popup and auto-dismiss

### DIFF
--- a/src/Components/Form.js
+++ b/src/Components/Form.js
@@ -1,23 +1,53 @@
 import "./FormStyles.css";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 const Form = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [botField, setBotField] = useState("");
+  const [popupMessage, setPopupMessage] = useState("");
+  const [popupType, setPopupType] = useState("success");
 
-  const currentUrl = useMemo(() => {
-    if (typeof window === "undefined") return "";
-    return window.location.href;
-  }, []);
+  useEffect(() => {
+    if (!popupMessage) return undefined;
 
-  const handleSubmit = (e) => {
+    const timer = setTimeout(() => {
+      setPopupMessage("");
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, [popupMessage]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
     if (botField.trim()) {
-      e.preventDefault();
       return;
     }
 
     setIsSubmitting(true);
+
+    try {
+      const formData = new FormData(e.target);
+      const response = await fetch("https://formsubmit.co/ajax/soumyajitbhadra20@gmail.com", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        throw new Error("Request failed");
+      }
+
+      setPopupType("success");
+      setPopupMessage("Message has been sent. I will contact you soon.");
+      e.target.reset();
+      setBotField("");
+    } catch (error) {
+      setPopupType("error");
+      setPopupMessage("Try again later.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -37,7 +67,6 @@ const Form = () => {
           <input type="hidden" name="_subject" value="Portfolio Contact: New Message" />
           <input type="hidden" name="_captcha" value="false" />
           <input type="hidden" name="_template" value="table" />
-          <input type="hidden" name="_next" value={currentUrl} />
 
           <label htmlFor="name">Your Name</label>
           <input id="name" name="name" type="text" placeholder="John Doe" required />
@@ -69,10 +98,9 @@ const Form = () => {
             {isSubmitting ? "Sending..." : "Send Message"}
           </button>
 
-          <p className="form-note">
-            On first use, FormSubmit may send an activation email to enable delivery.
-          </p>
         </form>
+
+        {popupMessage && <div className={`form-popup ${popupType}`}>{popupMessage}</div>}
       </div>
     </section>
   );

--- a/src/Components/FormStyles.css
+++ b/src/Components/FormStyles.css
@@ -81,6 +81,27 @@
     color: rgba(244, 244, 244, 0.7);
 }
 
+.form-popup {
+    position: fixed;
+    top: 24px;
+    right: 24px;
+    z-index: 999;
+    padding: 12px 16px;
+    border-radius: 10px;
+    color: #fff;
+    font-size: 0.9rem;
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.35);
+    animation: fadeIn 220ms ease-out;
+}
+
+.form-popup.success {
+    background: rgba(31, 161, 98, 0.95);
+}
+
+.form-popup.error {
+    background: rgba(196, 54, 54, 0.95);
+}
+
 .hidden-bot-field {
     position: absolute;
     left: -9999px;
@@ -99,6 +120,18 @@
     to {
         opacity: 1;
         transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
     }
 }
 


### PR DESCRIPTION
### Motivation

- Replace the previous `currentUrl` handling and synchronous form submit with an AJAX submission to provide inline success/error feedback and avoid relying on `window` during render. 
- Provide a visible, temporary confirmation UI so users know whether their message was sent or failed. 
- Prevent bot submissions via the hidden bot field while keeping the submit button disabled state during network activity.

### Description

- Replaced `useMemo`/`currentUrl` usage with `useEffect` and removed the `_next` hidden input to avoid accessing `window` during render. 
- Implemented an async `handleSubmit` that posts `FormData` to the `https://formsubmit.co/ajax/...` endpoint, manages `isSubmitting`, and resets the form on success. 
- Added `popupMessage` and `popupType` state and render of a `.form-popup` element to show success or error messages, with an auto-dismiss `useEffect` timer. 
- Added CSS rules for `.form-popup` (success/error states) and a `fadeIn` animation to style the notification.

### Testing

- Ran `npm run build` and the project built successfully. 
- Ran `npm test` and all tests passed. 
- Ran `npm run lint` and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b9f7eaac832aaabf1d0e7f7a75d8)